### PR TITLE
Fix ffi eval error

### DIFF
--- a/lambda-vc/lambda-vc.rkt
+++ b/lambda-vc/lambda-vc.rkt
@@ -207,8 +207,8 @@
           ;; curried. I don't know of a way around this.
           (let ([interp-args (map (λ (arg) (interp arg env))
                                   args)])
-            ;; Call out to Racket using `eval`.
-            (eval `(,(ffi-closure-func interp-func) ,@interp-args)))]
+            ;; Call out to Racket using `apply`.
+            (apply (ffi-closure-func interp-func) interp-args))]
          ;; Multary (application of 2 or more terms at once).
          [(< 1 (length args))
           ;; We rewrite the application as a staging of a single-argument


### PR DESCRIPTION
When I try to run
```
(require lambda-vc)
(interp '(+ 2 3))
```
I get the error
```
?: function application is not allowed;
 no #%app syntax transformer is bound in: (#<procedure:+> 2 3)
```
I could be doing something wrong, but this fixes the error for me by using an `apply` instead of an `eval` to run ffi functions like `+`.